### PR TITLE
Update links to match new username

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 
 addons:
   sonarcloud:
-    organization: "kazejiyu-github"
-    
+    organization: "echebbi-github"
+
 # Prevents "mvn install" default step
 install: true
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EKumi
 
-[![Build Status](https://travis-ci.org/KazeJiyu/ekumi.svg?branch=master)](https://travis-ci.org/KazeJiyu/ekumi) [![Documentation Status](https://readthedocs.org/projects/ekumi/badge/?version=latest)](https://ekumi.readthedocs.io/en/latest/?badge=latest) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/01ba3d3e1da44be78cb2267ed051b88a)](https://www.codacy.com/app/KazeJiyu/ekumi?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=KazeJiyu/ekumi&amp;utm_campaign=Badge_Grade) [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=fr.kazejiyu.ekumi%3Afr.kazejiyu.ekumi.root&metric=sqale_index)](https://sonarcloud.io/dashboard?id=fr.kazejiyu.ekumi%3Afr.kazejiyu.ekumi.root) [![codecov](https://codecov.io/gh/KazeJiyu/ekumi/branch/master/graph/badge.svg)](https://codecov.io/gh/KazeJiyu/ekumi) [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=fr.kazejiyu.ekumi%3Afr.kazejiyu.ekumi.root&metric=ncloc)](https://sonarcloud.io/dashboard?id=fr.kazejiyu.ekumi%3Afr.kazejiyu.ekumi.root)
+[![Build Status](https://travis-ci.org/echebbi/ekumi.svg?branch=master)](https://travis-ci.org/echebbi/ekumi) [![Documentation Status](https://readthedocs.org/projects/ekumi/badge/?version=latest)](https://ekumi.readthedocs.io/en/latest/?badge=latest) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/01ba3d3e1da44be78cb2267ed051b88a)](https://www.codacy.com/app/KazeJiyu/ekumi?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=echebbi/ekumi&amp;utm_campaign=Badge_Grade) [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=fr.kazejiyu.ekumi%3Afr.kazejiyu.ekumi.root&metric=sqale_index)](https://sonarcloud.io/dashboard?id=fr.kazejiyu.ekumi%3Afr.kazejiyu.ekumi.root) [![codecov](https://codecov.io/gh/echebbi/ekumi/branch/master/graph/badge.svg)](https://codecov.io/gh/echebbi/ekumi) [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=fr.kazejiyu.ekumi%3Afr.kazejiyu.ekumi.root&metric=ncloc)](https://sonarcloud.io/dashboard?id=fr.kazejiyu.ekumi%3Afr.kazejiyu.ekumi.root)
 
 Please check [the documentation](https://ekumi.kazejiyu.fr) for usages (_disclaimer_: the site is under construction).
 
@@ -9,6 +9,10 @@ Please check [the documentation](https://ekumi.kazejiyu.fr) for usages (_disclai
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md).
+
+## Contributions
+
+This project is currently a simple way for me to experiment new things; as such I am not expecting contributions at the moment.
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,10 @@
 		<jacoco-version>0.8.1</jacoco-version>
 
 		<!-- SONARQUBE -->
-		<sonar.links.homepage>https://github.com/KazeJiyu/ekumi</sonar.links.homepage>
-		<sonar.links.ci>https://travis-ci.org/KazeJiyu/ekumi</sonar.links.ci>
-		<sonar.links.scm>https://github.com/KazeJiyu/ekumi</sonar.links.scm>
-		<sonar.links.issue>https://github.com/KazeJiyu/ekumi/issues</sonar.links.issue>
+		<sonar.links.homepage>https://github.com/echebbi/ekumi</sonar.links.homepage>
+		<sonar.links.ci>https://travis-ci.org/echebbi/ekumi</sonar.links.ci>
+		<sonar.links.scm>https://github.com/echebbi/ekumi</sonar.links.scm>
+		<sonar.links.issue>https://github.com/echebbi/ekumi/issues</sonar.links.issue>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.java.source>8</sonar.java.source>
 		<!-- Ignore :

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,10 +4,10 @@ sonar.projectName=EKumi
 #   Meta-data for the project
 # =====================================================
 
-sonar.links.homepage=https://github.com/KazeJiyu/ekumi
-sonar.links.ci=https://travis-ci.org/KazeJiyu/ekumi
-sonar.links.scm=https://github.com/KazeJiyu/ekumi
-sonar.links.issue=https://github.com/KazeJiyu/ekumi/issues
+sonar.links.homepage=https://github.com/echebbi/ekumi
+sonar.links.ci=https://travis-ci.org/echebbi/ekumi
+sonar.links.scm=https://github.com/echebbi/ekumi
+sonar.links.issue=https://github.com/echebbi/ekumi/issues
 
 
 # =====================================================


### PR DESCRIPTION
I recently changed my GitHub username. As a consequence, some links were broken and must be updated.