### PR TITLE
Provide a contextual menu to execute an EDS model

### DIFF
--- a/bundles/fr.kazejiyu.ekumi.debug.ui/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Require-Bundle: fr.kazejiyu.ekumi.core;bundle-version="0.1.0",
  org.eclipse.core.runtime
 Bundle-Activator: fr.kazejiyu.ekumi.debug.ui.Activator
 Bundle-Vendor: Emmanuel CHEBBI
+Export-Package: fr.kazejiyu.ekumi.debug.ui

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/plugin.xml
@@ -2,36 +2,6 @@
 <?eclipse version="3.4"?>
 <plugin>
    <extension
-         point="org.eclipse.debug.ui.launchShortcuts">
-      <shortcut
-            class="fr.kazejiyu.ekumi.debug.ui.LaunchWorkflowShortcut"
-            description="Run an EKumi Workflow"
-            id="fr.kazejiyu.ekumi.launchConfiguration.ui.launchConfigurationType.shortcut"
-            label="Workflow"
-            modes="run">
-         <contextualLaunch>
-            <enablement>
-               <or>
-                  <adapt
-                        type="java.util.List">
-                     <iterate
-                           ifEmpty="false"
-                           operator="and">
-                        <adapt
-                              type="org.eclipse.core.resources.IFile">
-                           <test
-                                 property="org.eclipse.core.resources.extension"
-                                 value="workflow">
-                           </test>
-                        </adapt>
-                     </iterate>
-                  </adapt>
-               </or>
-            </enablement>
-         </contextualLaunch>
-      </shortcut>
-   </extension>
-   <extension
          point="org.eclipse.debug.ui.launchConfigurationTabGroups">
       <launchConfigurationTabGroup
             class="fr.kazejiyu.ekumi.debug.ui.form.EkumiTabGroup"

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/debug/ui/LaunchWorkflowFromFileShortcut.java
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/debug/ui/LaunchWorkflowFromFileShortcut.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.debug.core.DebugPlugin;
@@ -36,48 +35,38 @@ import fr.kazejiyu.ekumi.core.workflow.Activity;
 import fr.kazejiyu.ekumi.debug.EKumiRunConfiguration;
 
 /**
- * <p>Creates a new Launch Configuration for a given EKumi model.</p>
+ * <p>Creates a new Launch Configuration for a given EKumi model then runs it.</p>
  * 
- * <p>The {@link #launch(ISelection, String)} method is supposed to be called
- * from Eclipse IDE's contextual menu on an *.ekumi model file. It then creates
- * a corresponding Launch Configuration and runs it.</p>
+ * <p>This class is intended to be sub-classed by clients. It provides an easy way
+ * to add a _Run As_ shortcut on files serializing an EMF model that can be adapted
+ * to an EKumi {@link Activity}.</p>
  */
-public class LaunchWorkflowShortcut implements ILaunchShortcut {
+public abstract class LaunchWorkflowFromFileShortcut implements ILaunchShortcut {
 
 	@Override
 	public void launch(ISelection selection, String mode) {
 		URI fileURI = selectedFileURI(selection);
 		
-		if (fileURI == null)
+		if (fileURI == null) {
 			return;
-		
+		}
 		try {
-			Activity activity = loadActivity(fileURI);
-			
-			if (activity == null)
-				return;
-			
 			ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
 			ILaunchConfigurationType type = manager.getLaunchConfigurationType(EKumiRunConfiguration.ID);
 			ILaunchConfiguration[] configurations = manager.getLaunchConfigurations(type);
 			
 			// Create a new launch configuration
-			String launchConfigurationName = activity.getName();
-			int index = 1;
-			
-			while (configurationExists(configurations, launchConfigurationName)) {
-				++index;
-				launchConfigurationName = activity.getName() + " (" + index + ")";
-			}
+			String baseConfigurationName = configurationNameFor(fileURI);
+			String launchConfigurationName = availableLaunchConfigurationName(baseConfigurationName, configurations);
 			
 			ILaunchConfigurationWorkingCopy workingCopy = type.newInstance(null, launchConfigurationName);
-			workingCopy.setAttribute(EKumiRunConfiguration.EKUMI_MODEL_URI, activity.eResource().getURI().toString());
+			workingCopy.setAttribute(EKumiRunConfiguration.EKUMI_MODEL_URI, fileURI.toString());
 			ILaunchConfiguration configuration = workingCopy.doSave();
 			
 			// Run the new launch configuration
 			configuration.launch(ILaunchManager.RUN_MODE, null);
 			
-		} catch(CoreException | IOException e) {
+		} catch(Exception e) {
 			Activator.error(e, "An error occurred while launching the workflow " + fileURI);
 		}
 	}
@@ -85,6 +74,45 @@ public class LaunchWorkflowShortcut implements ILaunchShortcut {
 	@Override
 	public void launch(IEditorPart editor, String mode) {
 		// should not be called
+	}
+	
+	/**
+	 * <p>Returns the name of the new launch configuration that will be created
+	 * for the given fileURI.</p>
+	 * 
+	 * <p>Any exception thrown by this method will be properly handled.</p>
+	 * 
+	 * @param fileURI
+	 * 			The URI of the resource holding the model that is about to be executed.
+	 * 
+	 * @return the name of the new launch configuration
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	// Ignore the "Define and throw a dedicated exception instead of using a generic one." rule
+	// as "throw Exception" is used here on purpose to let client's code fail safely.
+	@SuppressWarnings("squid:S00112")
+	protected abstract String configurationNameFor(URI fileURI) throws Exception;
+
+	/**
+	 * Computes a launch configuration name that is not used by any existing configuration.
+	 * 
+	 * @param baseConfigurationName
+	 *			The name that serves as a base to compute the name of the new launch configuration.
+	 * @param configurations
+	 * 			The existing launch configurations to ensure that the computed name is unique.
+	 * 
+	 * @return a unique name based on given base name and that is not used by any existing launch configuration
+	 */
+	private static String availableLaunchConfigurationName(String baseConfigurationName, ILaunchConfiguration[] configurations) {
+		String launchConfigurationName = baseConfigurationName;
+		int index = 0;
+		
+		while (configurationExists(configurations, launchConfigurationName)) {
+			++index;
+			launchConfigurationName = baseConfigurationName + " (" + index + ")";
+		}
+		return launchConfigurationName;
 	}
 	
 	/**
@@ -115,18 +143,18 @@ public class LaunchWorkflowShortcut implements ILaunchShortcut {
 	 * @return the URI of the selected file, or null if no URI can be found from the selection 
 	 */
 	private static URI selectedFileURI(ISelection selection) {
-		if (selection.isEmpty())
+		if (selection.isEmpty()) {
 			return null;
-		
-		if (! (selection instanceof TreeSelection))
+		}
+		if (! (selection instanceof TreeSelection)) {
 			return null;
-		
+		}
 		IStructuredSelection tselection = (IStructuredSelection) selection;
 		Object selectedElement = tselection.getFirstElement();
 		
-		if (! (selectedElement instanceof PlatformObject))
+		if (! (selectedElement instanceof PlatformObject)) {
 			return null;
-		
+		}
 		PlatformObject object = (PlatformObject) selectedElement;
 		IPath path = object.getAdapter(IFile.class).getFullPath();
 		IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(path);
@@ -135,16 +163,21 @@ public class LaunchWorkflowShortcut implements ILaunchShortcut {
 	}
 	
 	/**
-	 * Loads an Activity from the given URI.
+	 * Loads an object from the given URI.
 	 * 
 	 * @param uri
 	 * 			The URI corresponding to the Resource to load.
 	 * 
+	 * @param <T>
+	 * 			The exact type of the object to load.
+	 * 
 	 * @return the loaded Activity or {@code null} if the Resource does not contain any
 	 * 
 	 * @throws IOException if an I/O error occurs while loading the Resource
+	 * @throws ClassCastException if the loaded object cannot be casted to T
 	 */
-	private static Activity loadActivity(URI uri) throws IOException {
+	@SuppressWarnings("unchecked")
+	protected static <T> T load(URI uri) throws IOException {
 		ResourceSet resourceSet = new ResourceSetImpl();
 		Resource resource = resourceSet.createResource(uri);
 		resource.load(Collections.emptyMap());
@@ -152,7 +185,7 @@ public class LaunchWorkflowShortcut implements ILaunchShortcut {
 		if (resource.getContents().isEmpty())
 			return null;
 		
-		return (Activity) resource.getContents().get(0);
+		return (T) resource.getContents().get(0);
 	}
 
 }

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/debug/ui/form/ChooseActivityModelTab.java
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/debug/ui/form/ChooseActivityModelTab.java
@@ -110,10 +110,10 @@ public class ChooseActivityModelTab extends AbstractLaunchConfigurationTab {
 			ElementTreeSelectionDialog dialog = new ElementTreeSelectionDialog(shell, new WorkbenchLabelProvider(), new BaseWorkbenchContentProvider());
 			
 			dialog.setTitle("Workspace");
-			dialog.setMessage("Select an activity (*.ekumi)");
+			dialog.setMessage("Select an activity");
 			dialog.setInput(ResourcesPlugin.getWorkspace().getRoot());
 			
-			if (dialog.open() == Dialog.OK) {
+			if (dialog.open() == Dialog.OK && dialog.getResult().length > 0) {
 				Object selected = dialog.getResult()[0];
 				
 				PlatformObject object = (PlatformObject) selected;

--- a/bundles/fr.kazejiyu.ekumi.debug/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.debug/plugin.xml
@@ -5,6 +5,8 @@
          point="org.eclipse.debug.core.launchConfigurationTypes">
       <launchConfigurationType
             delegate="fr.kazejiyu.ekumi.debug.RunWorkflow"
+            delegateDescription="Executes an EKumi activity in background"
+            delegateName="EKumi Activity Launcher"
             id="fr.kazejiyu.ekumi.launchConfiguration.launchConfigurationType"
             modes="run"
             name="Workflow">

--- a/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/EKumiRunConfiguration.java
+++ b/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/EKumiRunConfiguration.java
@@ -14,10 +14,10 @@ package fr.kazejiyu.ekumi.debug;
  */
 public final class EKumiRunConfiguration {
 	
-	/** ID of the EKumi extension contribution to the org.eclipse.debug.ui.launchShortcuts extension point */
+	/** ID of the extension contribution providing an EKumi Launch Configuration. */
 	public static final String ID = "fr.kazejiyu.ekumi.launchConfiguration.launchConfigurationType";
 	
-	/** Name of the configuration's attribute used to specify the URI of the Activity to execute */
+	/** Name of the configuration's attribute used to specify the URI of the Activity to execute. */
 	public static final String EKUMI_MODEL_URI = "fr.kazejiyu.ekumi.launchConfiguration.model";
 	
 	private EKumiRunConfiguration() {

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/.classpath
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/.project
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.ekumi.specs.eds.debug.ui</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: EKumi EDS Launch Configuration
+Bundle-SymbolicName: fr.kazejiyu.ekumi.specs.eds.debug.ui;singleton:=true
+Bundle-Version: 0.1.0
+Bundle-Vendor: Emmanuel CHEBBI
+Automatic-Module-Name: fr.kazejiyu.ekumi.specs.eds.debug.ui
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.eclipse.debug.ui;bundle-version="[3.0.0,4.0.0)",
+ org.eclipse.ui.ide;bundle-version="[3.0.0,4.0.0)",
+ org.eclipse.jface;bundle-version="[3.0.0,4.0.0)",
+ fr.kazejiyu.ekumi.debug.ui;bundle-version="0.1.0",
+ org.eclipse.emf.common;bundle-version="[2.0.0,3.0.0)",
+ fr.kazejiyu.ekumi.specs.eds;bundle-version="0.1.0"

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/build.properties
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/plugin.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.debug.ui.launchShortcuts">
+      <shortcut
+            class="fr.kazejiyu.ekumi.specs.eds.debug.ui.LaunchEdsModelShortcut"
+            id="fr.kazejiyu.ekumi.specs.eds.debug.ui.launchConfigurationShortcut"
+            label="EKumi Activity"
+            modes="run">
+         <contextualLaunch>
+            <enablement>
+               <or>
+                  <adapt
+                        type="java.util.List">
+                     <iterate
+                           ifEmpty="false"
+                           operator="and">
+                        <adapt
+                              type="org.eclipse.core.resources.IFile">
+                           <test
+                                 property="org.eclipse.core.resources.extension"
+                                 value="eds">
+                           </test>
+                        </adapt>
+                     </iterate>
+                  </adapt>
+               </or>
+            </enablement>
+         </contextualLaunch>
+      </shortcut>
+   </extension>
+
+</plugin>

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/src/fr/kazejiyu/ekumi/specs/eds/debug/ui/LaunchEdsModelShortcut.java
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.debug.ui/src/fr/kazejiyu/ekumi/specs/eds/debug/ui/LaunchEdsModelShortcut.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (C) 2018-2019 Emmanuel CHEBBI
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package fr.kazejiyu.ekumi.specs.eds.debug.ui;
+
+import java.io.IOException;
+
+import org.eclipse.emf.common.util.URI;
+
+import fr.kazejiyu.ekumi.debug.ui.LaunchWorkflowFromFileShortcut;
+import fr.kazejiyu.ekumi.specs.eds.Activity;
+
+/**
+ * <p>Launches the execution of an EDS {@link Activity}.</p>
+ * 
+ * <p>The {@link #launch(org.eclipse.jface.viewers.ISelection, String) launch} method
+ * is supposed to be called from Eclipse IDE's contextual menu on a _*.eds_ model file.
+ * It then creates a new launch configuration and runs it.</p>
+ */
+public class LaunchEdsModelShortcut extends LaunchWorkflowFromFileShortcut {
+
+	@Override
+	protected String configurationNameFor(URI fileURI) throws IOException {
+		Activity activity = load(fileURI);
+		return activity.getName();
+	}
+
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -29,6 +29,7 @@
         <module>fr.kazejiyu.ekumi.languages.java.ide</module>
         <module>fr.kazejiyu.ekumi.specs.eds</module>
         <module>fr.kazejiyu.ekumi.specs.eds.adapter</module>
+        <module>fr.kazejiyu.ekumi.specs.eds.debug.ui</module>
         <module>fr.kazejiyu.ekumi.specs.eds.design</module>
         <module>fr.kazejiyu.ekumi.specs.eds.edit</module>
         <module>fr.kazejiyu.ekumi.specs.eds.editor</module>

--- a/docs/available-representations/ekumi-default-representation.rst
+++ b/docs/available-representations/ekumi-default-representation.rst
@@ -73,3 +73,25 @@ Link two tasks
 .. |precede-tool| image:: images/precede_tool.png
 
 Two task can be linked in order to specify which one should be executed first. This can be achieved thanks to the |precede-tool|.
+
+Launch an activity
+-------------------
+
+Once the activity is ready, it can be executed. An execution can be launched in two ways.
+
+Create a dedicated launch configuration
+```````````````````````````````````````
+
+1. ``Run`` > ``Run Configurations...``
+2. Double-click on `Workflow`
+3. Click on `Browse`
+4. Select the `.eds` file located under the `model/` folder
+5. Click on `Run`
+
+Use the context menu shortcut
+`````````````````````````````
+
+In the file explorer:
+
+1. Right-click on the `.eds` file located under the `model/` folder
+2. Select ``Run As`` > ``EKumi Activity``

--- a/features/fr.kazejiyu.ekumi.specs.eds.feature/feature.xml
+++ b/features/fr.kazejiyu.ekumi.specs.eds.feature/feature.xml
@@ -313,6 +313,10 @@ version(s), and exceptions or additional permissions here}.&quot;
       <import plugin="fr.kazejiyu.ekumi.ide.common" version="0.1.0" match="greaterOrEqual"/>
       <import plugin="fr.kazejiyu.ekumi.ide" version="0.1.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.sirius.ext.base"/>
+      <import plugin="org.eclipse.debug.ui" version="3.0.0" match="compatible"/>
+      <import plugin="org.eclipse.jface" version="3.0.0" match="compatible"/>
+      <import plugin="fr.kazejiyu.ekumi.debug.ui" version="0.1.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.emf.common" version="2.0.0" match="compatible"/>
    </requires>
 
    <plugin
@@ -331,6 +335,13 @@ version(s), and exceptions or additional permissions here}.&quot;
 
    <plugin
          id="fr.kazejiyu.ekumi.specs.eds.design"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="fr.kazejiyu.ekumi.specs.eds.debug.ui"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
The `LaunchWorkflowFromFile` class makes easier for clients to implement contextual shortcut for their own EMF models. See `LaunchEdsModelShortcut` for an example.

To trigger this contextual menu:
 - Right-click on the *.eds file
 - Run As > EKumi Activity

![image](https://user-images.githubusercontent.com/25926433/57109251-42a03280-6d35-11e9-8bb7-7d32e272410c.png)
